### PR TITLE
Add center tile sampling measurement operator and config

### DIFF
--- a/configs/tasks/micro_center_sampling.yaml
+++ b/configs/tasks/micro_center_sampling.yaml
@@ -1,0 +1,19 @@
+conditioning:
+  method: ps
+  params:
+    scale: 1.0            # TUNE: data-consistency weight
+data:
+  name: generic_images
+  root: "\\data\\micro\\test"   # use \\ for Windows path escaping
+measurement:
+  operator:
+    name: center_tile_sampling
+    s: 3                  # start with 3; later sweep 2..9
+    in_shape: [1, 3, 512, 512]  # set to your typical size (optional)
+  noise:
+    name: clean           # faithful to microscope (no extra noise)
+sampler:
+  ddim_steps: 50          # TUNE: number of sampling steps
+  ddim_eta: 0.0
+save:
+  dir: "./results/micro_center"

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -35,6 +35,22 @@ def save_image_3d(tensor, slice_idx, file_name):
     vutils.save_image(image_grid, file_name, nrow=1)
 
 
+def save_image_grid(tensors, path):
+    """Save a horizontal grid of tensors to ``path``.
+
+    Each tensor is expected to be ``(C,H,W)`` in ``[-1,1]`` or ``[0,1]``. All
+    tensors are converted to ``[0,1]`` and concatenated along width.
+    """
+    ts = []
+    for t in tensors:
+        if t.min() < 0:
+            t = (t + 1) / 2.0
+        ts.append(t.clamp(0, 1))
+    grid = torch.cat(ts, dim=-1)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    vutils.save_image(grid, path)
+
+
 
 def map_coordinates(input, coordinates):
     ''' PyTorch version of scipy.ndimage.interpolation.map_coordinates


### PR DESCRIPTION
## Summary
- add `CenterTileSamplingOperator` with adjoint alias and torch import
- support center-tile sampling in `sample_condition.py` and save triptych panels
- include helper to save image grids and task config for micro center sampling

## Testing
- `python - <<'PY'
import types, sys
motionblur = types.ModuleType('motionblur')
motionblur.motionblur = types.ModuleType('motionblur.motionblur')
class DummyKernel: pass
motionblur.motionblur.Kernel = DummyKernel
sys.modules['motionblur'] = motionblur
sys.modules['motionblur.motionblur'] = motionblur.motionblur
import torch
from ldm_inverse.measurements import CenterTileSamplingOperator
A = CenterTileSamplingOperator(s=4, device='cpu', in_shape=[1,3,256,256])
x = torch.randn(1,3,256,256)
y = torch.randn(1,3,256//4,256//4)
lhs = (A.forward(x) * y).sum()
rhs = (x * A.adjoint(y, H=256, W=256)).sum()
print('inner product diff:', (lhs - rhs).abs().item())
PY`
- `pytest` (fails: ModuleNotFoundError: No module named 'imwatermark')

------
https://chatgpt.com/codex/tasks/task_e_68986f9a5bf0832aa1611be2a4f3c697